### PR TITLE
Fixed ShoukakuRest#resolve optional search param

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -141,7 +141,7 @@ declare module 'shoukaku' {
     public timeout: number;
     public url: string;
 
-    public resolve(identifier: string, search: Source): Promise<ShoukakuTrackList | null>;
+    public resolve(identifier: string, search?: Source): Promise<ShoukakuTrackList | null>;
     public decode(track: Base64String): Promise<Object>;
     public getRoutePlannerStatus(): Promise<Object>;
     public unmarkFailedAddress(address: string): Promise<number>;


### PR DESCRIPTION
The `search` parameter in `ShoukakuRest#resolve(identifier, search)` is incorrectly marked as required. This causes TS to give warning which can be annoying if you forgot how to ignore errors (which from what I've read, ignores all errors anyway).

This is just a simple fix.