### PR TITLE
Implement bug fix. See below.

### DIFF
--- a/src/guild/ShoukakuPlayer.js
+++ b/src/guild/ShoukakuPlayer.js
@@ -276,6 +276,11 @@ class ShoukakuPlayer extends EventEmitter {
             event === 'nodeDisconnect' ? this.reset(true) : this.reset();
             return super.emit(event, data);
         }
+
+        if (event === "start") {
+            this.track = data.track;
+        }
+
         if (data && data.position) this.position = data.position;
         return super.emit(event, data);
     }

--- a/src/guild/ShoukakuPlayer.js
+++ b/src/guild/ShoukakuPlayer.js
@@ -277,7 +277,7 @@ class ShoukakuPlayer extends EventEmitter {
             return super.emit(event, data);
         }
 
-        if (event === "start") {
+        if (event === 'start') {
             this.track = data.track;
         }
 

--- a/src/guild/ShoukakuPlayer.js
+++ b/src/guild/ShoukakuPlayer.js
@@ -277,9 +277,7 @@ class ShoukakuPlayer extends EventEmitter {
             return super.emit(event, data);
         }
 
-        if (event === 'start') {
-            this.track = data.track;
-        }
+        if (event === 'start') this.track = data.track;
 
         if (data && data.position) this.position = data.position;
         return super.emit(event, data);


### PR DESCRIPTION
Bug:
`ShoukakuPlayer#track` is incorrectly null.

Cause:
`ShoukakuPlayer#playTrack(track, { noReplace: false })`

When `ShoukakuPlayer#playTrack(track, { noReplace: false }` is called, `ShoukakuPlayer#track` is set correctly to the new track. However, the following `end` event sets it to null. The `end` event occurs because of `{ noReplace: false }` provided in the function.

Fix:
Listen to the `start` event and set `ShoukakuPlayer#track` to the track stored in the event data. This will also help with keeping Shoukaku and LavaLink synced.