### PR TITLE
Check for Number.isNaN() and not Number.isInteger()

### DIFF
--- a/src/guild/ShoukakuPlayer.js
+++ b/src/guild/ShoukakuPlayer.js
@@ -218,7 +218,7 @@ class ShoukakuPlayer extends EventEmitter {
      * @returns {Promise<ShoukakuPlayer>}
      */
     async setVolume(volume) {
-        if (!Number.isInteger(volume)) 
+        if (Number.isNaN(volume)) 
             throw new ShoukakuError('Please input a valid number for volume');
         volume = Math.min(5, Math.max(0, volume));
         if (volume === this.filters.volume) return this;


### PR DESCRIPTION
The `Volume` value now ranges from `0` to `5` and it doesn't have to be an `Integer` anymore since `0.1` or `4.5` for example are also allowed