### PR TITLE
feat: searching on youtube music

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -41,7 +41,7 @@ declare module 'shoukaku' {
     };
   }
 
-  export type Source = 'youtube' | 'soundcloud';
+  export type Source = 'youtube' | 'soundcloud' | 'youtubemusic';
 
   export enum ShoukakuStatus {
     CONNECTING = 'CONNECTING',

--- a/src/rest/ShoukakuRest.js
+++ b/src/rest/ShoukakuRest.js
@@ -36,7 +36,7 @@ class ShoukakuRest {
     /**
     * Resolves a identifier into a lavalink track.
     * @param {string} identifier Anything you want for lavalink to search for
-    * @param {string} search Either `youtube` or `soundcloud`. If specified, resolve will return search results.
+    * @param {string} [search] Either `youtube` or `soundcloud` or `youtubemusic`. If specified, resolve will return search results.
     * @memberof ShoukakuRest
     * @returns {Promise<null|ShoukakuTrackList>} The parsed data from Lavalink rest
     */

--- a/src/util/ShoukakuUtil.js
+++ b/src/util/ShoukakuUtil.js
@@ -1,5 +1,5 @@
 const ShoukakuError = require('../constants/ShoukakuError.js');
-const SearchTypes = { 'soundcloud': 'scsearch', 'youtube': 'ytsearch' };
+const SearchTypes = { 'soundcloud': 'scsearch', 'youtube': 'ytsearch', 'youtubemusic': 'ytmsearch' };
 
 class ShoukakuUtil {
     static mergeDefault(def, given) {


### PR DESCRIPTION
the feature has been added since lavaplayer 1.3.67 by using `ytmsearch` prefix. so this implements it

note: the lavalink dev branch currently uses lavaplayer 1.3.69