### PR TITLE
Move volume to player object

### DIFF
--- a/src/guild/ShoukakuPlayer.js
+++ b/src/guild/ShoukakuPlayer.js
@@ -129,6 +129,7 @@ class ShoukakuPlayer extends EventEmitter {
      * @param {Object} [options={}] Used if you want to put a custom track start or end time
      * @param {boolean} [options.noReplace=true] Specifies if the player will not replace the current track when executing this action
      * @param {boolean} [options.pause=false] If `true`, the player will pause when the track starts playing
+     * @param {?number} [options.volume=100] Volume for thr track
      * @param {?number} [options.startTime=undefined] In milliseconds on when to start
      * @param {?number} [options.endTime=undefined] In milliseconds on when to end
      * @memberOf ShoukakuPlayer
@@ -143,6 +144,7 @@ class ShoukakuPlayer extends EventEmitter {
             guildId: this.connection.guildID,
             track: input,
             noReplace: options.noReplace,
+            volume: options.volume ?? 100,
             pause: options.pause
         };
         if (options.startTime) payload.startTime = options.startTime;

--- a/src/guild/ShoukakuPlayer.js
+++ b/src/guild/ShoukakuPlayer.js
@@ -24,6 +24,11 @@ class ShoukakuPlayer extends EventEmitter {
          */
         this.connection = new ShoukakuConnection(this, node, options);
         /**
+          * The volume of this filter
+          * @type {?Number}
+          */
+        this.volume = 100;
+        /**
          * The track that is currently being played by this player
          * @type {?string}
          */
@@ -144,7 +149,7 @@ class ShoukakuPlayer extends EventEmitter {
             guildId: this.connection.guildID,
             track: input,
             noReplace: options.noReplace,
-            volume: options.volume ?? 100,
+            volume: options.volume ?? this.volume,
             pause: options.pause
         };
         if (options.startTime) payload.startTime = options.startTime;
@@ -207,7 +212,7 @@ class ShoukakuPlayer extends EventEmitter {
     setVolume(volume) {
         if (Number.isNaN(volume)) throw new Error('Please input a valid number for volume');
         volume = Math.min(5, Math.max(0, volume));
-        this.filters.volume = volume;
+        this.volume = volume;
         this.updateFilters();
         return this;
     }
@@ -383,11 +388,10 @@ class ShoukakuPlayer extends EventEmitter {
      * @private
      */
     updateFilters() {
-        const { volume, equalizer, karaoke, timescale, tremolo, vibrato, rotation, distortion } = this.filters;
+        const { equalizer, karaoke, timescale, tremolo, vibrato, rotation, distortion } = this.filters;
         this.connection.node.send({
             op: 'filters',
             guildId: this.connection.guildID,
-            volume,
             equalizer,
             karaoke,
             timescale,

--- a/src/guild/ShoukakuPlayer.js
+++ b/src/guild/ShoukakuPlayer.js
@@ -213,7 +213,11 @@ class ShoukakuPlayer extends EventEmitter {
         if (Number.isNaN(volume)) throw new Error('Please input a valid number for volume');
         volume = Math.min(5, Math.max(0, volume));
         this.volume = volume;
-        this.updateFilters();
+        this.connection.node.send({
+            op: "volume",
+            guildId: this.connection.guildID,
+            volume: volume
+        });
         return this;
     }
     /**

--- a/src/struct/ShoukakuFilter.js
+++ b/src/struct/ShoukakuFilter.js
@@ -5,7 +5,6 @@
 class ShoukakuFilter {
     /** 
      * @param {Object} [settings={}] Settings to initialize this filter with
-     * @param {Number} [settings.volume=1.0] Volume of this filter 
      * @param {Object[]} [settings.equalizer=[]] Equalizer of this filter
      * @param {number} settings.equalizer.band Band of the equalizer, can be 0 - 13
      * @param {number} settings.equalizer.gain Gain for this band of the equalizer
@@ -44,11 +43,6 @@ class ShoukakuFilter {
      * @param {number} [settings.lowPass.smoothing] Sets the smoothing of low pass filter
      */
     constructor(settings = {}) {
-        /**
-         * The volume of this filter
-         * @type {Number}
-         */
-        this.volume = settings.volume || 1.0;
         /**
          * The equalizer bands set for this filter
          * @type {Object[]}

--- a/types/guild/ShoukakuPlayer.d.ts
+++ b/types/guild/ShoukakuPlayer.d.ts
@@ -15,6 +15,7 @@ export class ShoukakuPlayer extends EventEmitter {
     public track?: Base64String | null;
     public paused: boolean;
     public position: number;
+    public volume: number;
     public filters: ShoukakuFilter;
 
     public moveNode(name: string): ShoukakuPlayer;

--- a/types/struct/ShoukakuFilter.d.ts
+++ b/types/struct/ShoukakuFilter.d.ts
@@ -3,7 +3,6 @@ export class ShoukakuFilter {
         settings: FilterSettings
     )
 
-    public volume: number;
     public equalizer: FilterEqSettings[];
     public karaoke: FilterKaraokeSettings | null;
     public timescale: FilterTimescaleSettings | null;
@@ -14,7 +13,6 @@ export class ShoukakuFilter {
 }
 
 export interface FilterSettings {
-    volume: number,
     equalizer: FilterEqSettings[],
     karaoke: FilterKaraokeSettings,
     timescale: FilterTimescaleSettings,


### PR DESCRIPTION
This pr moves volume to player and removes it from filter.

feel free to turn down this pr if you want the volume to be still in the filter object