### PR TITLE
feat(Resume): Override ShoukakuPlayer#playTrack options when resuming

### DIFF
--- a/src/guild/ShoukakuPlayer.js
+++ b/src/guild/ShoukakuPlayer.js
@@ -363,7 +363,7 @@ class ShoukakuPlayer extends EventEmitter {
     /**
      * Tries to resume your player, a use case for this is when you do ShoukakuPlayer.connection.attemptReconnect()
      * @memberOf ShoukakuPlayer
-     * @param {Object} [options={}] Override any options that are passed to playTrack when resuming playback.
+     * @param {Object} [options={}] Used if you want to change noReplace, pause, put a custom track start or end time
      * @returns {ShoukakuPlayer}
      * @example
      * ShoukakuPlayer

--- a/src/guild/ShoukakuPlayer.js
+++ b/src/guild/ShoukakuPlayer.js
@@ -363,6 +363,7 @@ class ShoukakuPlayer extends EventEmitter {
     /**
      * Tries to resume your player, a use case for this is when you do ShoukakuPlayer.connection.attemptReconnect()
      * @memberOf ShoukakuPlayer
+     * @param {Object} [options={}] Override any options that are passed to playTrack when resuming playback.
      * @returns {ShoukakuPlayer}
      * @example
      * ShoukakuPlayer
@@ -370,9 +371,13 @@ class ShoukakuPlayer extends EventEmitter {
      *   .reconnect()
      *   .then(() => ShoukakuPlayer.resume());
      */
-    resume() {
+    resume(options = {}) {
         this.updateFilters();
-        if (this.track) this.playTrack(this.track, { startTime: this.position, pause: this.paused });
+        if (this.track) {
+            options = mergeDefault({ startTime: this.position, pause: this.paused }, options);
+
+            this.playTrack(this.track, options);
+        }
         this.emit('resumed');
         return this;
     }

--- a/types/guild/ShoukakuPlayer.d.ts
+++ b/types/guild/ShoukakuPlayer.d.ts
@@ -33,7 +33,7 @@ export class ShoukakuPlayer extends EventEmitter {
   public setLowPass(values: { smoothing?: number } | null): ShoukakuPlayer;
   public setFilters(settings: ShoukakuFilter): ShoukakuPlayer;
   public clearFilters(): ShoukakuPlayer;
-  public resume(): ShoukakuPlayer;
+  public resume(options?: { noReplace?: boolean, pause?: boolean, startTime?: number, endTime?: number }): ShoukakuPlayer;
   private updateFilters(): void;
   protected clean(): void;
   protected reset(): void;


### PR DESCRIPTION
Sometimes while resuming, the LavaLink node might still be playing and ignore the resume request.

With this PR you can modify the options passed to playTrack without losing the functionality that resume provides.

Example
```js
// by default noReplace is set to true
ShoukakuPlayer.resume({ noReplace: false });
```