### PR TITLE
fix(Connector#ready): node options are being merged with Shoukaku defaults

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -5,20 +5,20 @@ export type Constructor<T> = new (...args: any[]) => T;
  * @param given User input
  * @returns Merged options
  */
-export function mergeDefault(def: any, given: any): any {
-    if (!given) return def;
-    const defaultKeys = Object.keys(def);
-    for (const key of defaultKeys) {
-        if (def[key] === null) {
-            if (!given[key]) throw new Error(`${key} was not found from the given options.`);
-        }
-        if (given[key] === null || given[key] === undefined) given[key] = def[key];
-    }
-    for (const key in defaultKeys) {
+export function mergeDefault<T extends { [key: string]: any }>(def: T, given: T): Required<T> {
+    if (!given) return def as Required<T>;
+    const defaultKeys: (keyof T)[] = Object.keys(def);
+    for (const key in given) {
         if (defaultKeys.includes(key)) continue;
         delete given[key];
     }
-    return given;
+    for (const key of defaultKeys) {
+        if (def[key] === null || (typeof def[key] === 'string' && def[key].length === 0)) {
+            if (!given[key]) throw new Error(`${String(key)} was not found from the given options.`);
+        }
+        if (given[key] === null || given[key] === undefined) given[key] = def[key];
+    }
+    return given as Required<T>;
 }
 
 /**

--- a/src/connectors/Connector.ts
+++ b/src/connectors/Connector.ts
@@ -1,5 +1,5 @@
 import { NodeOption, Shoukaku } from '../Shoukaku';
-import { ShoukakuDefaults } from '../Constants';
+import { NodeDefaults } from '../Constants';
 import { mergeDefault } from '../Utils';
 
 export interface ConnectorMethods {
@@ -23,7 +23,7 @@ export abstract class Connector {
     protected ready(nodes: NodeOption[]): void {
         this.manager!.id = this.getId();
         this.manager!.emit('debug', 'Manager', `[Manager] : Connecting ${nodes.length} nodes`);
-        for (const node of nodes) this.manager!.addNode(mergeDefault(ShoukakuDefaults, node));
+        for (const node of nodes) this.manager!.addNode(mergeDefault(NodeDefaults, node));
     }
 
     protected raw(packet: any): void {


### PR DESCRIPTION
- [fix(Connector): node options are being merged with Shoukaku defaults](https://github.com/allvzx/Shoukaku/commit/cffc90f0f5a05e0a7b38a0deebe9cd3e345750dc)
- [feat(Util): improve mergeDefault typings and function](https://github.com/allvzx/Shoukaku/commit/8fa683c992746c3fe6f795bf8f11b2b56c76a386)
- - replace `any` to generic type in parameters type and return type
- - add check if the default value is an empty string https://github.com/Deivu/Shoukaku/blob/8fa683c992746c3fe6f795bf8f11b2b56c76a386/src/Utils.ts#L16
- - and i suppose this should read the given keys instead of default keys to remove unnecessary fields or no? https://github.com/Deivu/Shoukaku/blob/afb4ed48e47404997f96b2283baf1efb38482b36/src/Utils.ts#L17