### PR TITLE
fix: export Connector

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,7 @@
 export * as Connectors from './src/connectors/libs';
 export * as Constants from './src/Constants';
 export * as Utils from './src/Utils';
+export * from './src/connectors/Connector';
 export * from './src/guild/Connection';
 export * from './src/guild/Player';
 export * from './src/node/Node';


### PR DESCRIPTION
As mentioned in https://github.com/Deivu/Shoukaku/blob/master/src/connectors/README.md, the library allows to create your own Connector to support other wrappers for the Discord API.

But the Connector class is not exported from the library, which creates an error:
![image](https://user-images.githubusercontent.com/44965055/197397076-73f77cb9-386b-4c4f-b97e-4e23b889d2e7.png)

This PR fixes this, adding the ability to correctly add custom connectors.