### PR TITLE
Fix Typo in Docs

### DIFF
--- a/docs/classes/guild_Player.Player.html
+++ b/docs/classes/guild_Player.Player.html
@@ -128,7 +128,7 @@
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="connection" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagReadonly">Readonly</code> <span>connection</span><a href="#connection" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">connection<span class="tsd-signature-symbol">:</span> <a href="guild_Connection.Connection.html" class="tsd-signature-type" data-tsd-kind="Class">Connection</a></div>
-<div class="tsd-comment tsd-typography"><p>Discort voice channel that this player is connected to</p>
+<div class="tsd-comment tsd-typography"><p>Discord voice channel that this player is connected to</p>
 </div><aside class="tsd-sources">
 <ul>
 <li>Defined in <a href="https://github.com/Deivu/Shoukaku/blob/78d102d/src/guild/Player.ts#L224">src/guild/Player.ts:224</a></li></ul></aside></section>


### PR DESCRIPTION
* `Discort` -> `Discord`