### PR TITLE
Fix Typo in Docs

### DIFF
--- a/src/guild/Player.ts
+++ b/src/guild/Player.ts
@@ -220,7 +220,7 @@ export class Player extends EventEmitter {
      */
     public node: Node;
     /**
-     * Discort voice channel that this player is connected to
+     * Discord voice channel that this player is connected to
      */
     public readonly connection: Connection;
     /**


### PR DESCRIPTION
* `Discort` -> `Discord`