### PR TITLE
Fix typo in src/node/Node.ts

### DIFF
--- a/src/node/Node.ts
+++ b/src/node/Node.ts
@@ -284,7 +284,7 @@ export class Node extends EventEmitter {
      */
     private open(response: IncomingMessage): void {
         const resumed = response.headers['session-resumed'] === 'true';
-        this.emit('debug', `[Socket] <-> [${this.name}] : Connection Handshake Done! ${this.url} | Upgrade Headers Resuned: ${resumed}`);
+        this.emit('debug', `[Socket] <-> [${this.name}] : Connection Handshake Done! ${this.url} | Upgrade Headers Resumed: ${resumed}`);
         this.reconnects = 0;
         this.state = State.NEARLY;
     }


### PR DESCRIPTION
There's a typo in this line: 
```ts
this.emit('debug', `[Socket] <-> [${this.name}] : Connection Handshake Done! ${this.url} | Upgrade Headers Resuned: ${resumed}`);
```

`Resuned` -> `Resumed`  
Doesn't matter too much since it's in debug output, but it's there 😄