### PR TITLE
Fix voiceConnectionTimeout option is not applied correctly

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -40,7 +40,8 @@ export const ShoukakuDefaults: ShoukakuOptions = {
     restTimeout: 60,
     moveOnDisconnect: false,
     userAgent: `${Info.name}bot/${Info.version} (${Info.repository.url})`,
-    structures: {}
+    structures: {},
+    voiceConnectionTimeout: 15
 };
 
 export const NodeDefaults: NodeOption = {

--- a/src/guild/Connection.ts
+++ b/src/guild/Connection.ts
@@ -167,7 +167,7 @@ export class Connection extends EventEmitter {
         this.player.node.emit('debug', `[Voice] -> [Discord] : Requesting Connection | Guild: ${this.guildId}`);
 
         const controller = new AbortController();
-        const timeout = setTimeout(() => controller.abort(), (this.player.node.manager.options.voiceConnectionTimeout ?? 15) * 1000);
+        const timeout = setTimeout(() => controller.abort(), this.player.node.manager.options.voiceConnectionTimeout * 1000);
 
         try {
             const [ status, error ] = await once(this, 'connectionUpdate', { signal: controller.signal });


### PR DESCRIPTION
`voiceConnectionTimeout` is not in `ShoukakuDefaults`, so when `mergeDefault()` is called, `options.voiceConnectionTimeout` becomes `undefined`.

Adding `voiceConnectionTimeout` to `ShoukakuDefaults` fixes this.