### PR TITLE
Lavalink v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,6 @@ resume | boolean | Whether to resume a connection on disconnect to Lavalink (Ser
 sessionId | string | Session ID for lavalink to resume |
 resumeTimeout | number | Timeout before resuming a connection **in seconds** |
 resumeByLibrary | boolean | Whether to resume the players by doing it in the library side (Client Side) (Note: TRIES TO RESUME REGARDLESS OF WHAT HAPPENED ON A LAVALINK SERVER) |
-alwaysSendSessionId | boolean | Disables the first time initialization tracking of nodes, and just sends the session id always (Note: Useful for people who save their players to redis and wants to resume sessions even at first boot) |
 reconnectTries | number | Number of times to try and reconnect to Lavalink before giving up |
 reconnectInterval | number | Timeout before trying to reconnect **in seconds** |
 restTimeout | number | Time to wait for a response from the Lavalink REST API before giving up **in seconds** |

--- a/README.md
+++ b/README.md
@@ -204,10 +204,10 @@ console.log(shoukaku.getIdealNode());
  Option | Type | Description
 --------|------|------------
 resume | boolean | Whether to resume a connection on disconnect to Lavalink (Server Side) (Note: DOES NOT RESUME WHEN THE LAVALINK SERVER DIES) |
-resumeKey | string | Resume key for Lavalink |
+sessionId | string | Session ID for lavalink to resume |
 resumeTimeout | number | Timeout before resuming a connection **in seconds** |
 resumeByLibrary | boolean | Whether to resume the players by doing it in the library side (Client Side) (Note: TRIES TO RESUME REGARDLESS OF WHAT HAPPENED ON A LAVALINK SERVER) |
-alwaysSendResumeKey | boolean | Disables the first time initialization tracking of nodes, and just sends the resume key always (Note: Useful for people who save their players to redis and wants to resume sessions even at first boot) |
+alwaysSendSessionId | boolean | Disables the first time initialization tracking of nodes, and just sends the session id always (Note: Useful for people who save their players to redis and wants to resume sessions even at first boot) |
 reconnectTries | number | Number of times to try and reconnect to Lavalink before giving up |
 reconnectInterval | number | Timeout before trying to reconnect **in seconds** |
 restTimeout | number | Time to wait for a response from the Lavalink REST API before giving up **in seconds** |

--- a/README.md
+++ b/README.md
@@ -204,7 +204,6 @@ console.log(shoukaku.getIdealNode());
  Option | Type | Description
 --------|------|------------
 resume | boolean | Whether to resume a connection on disconnect to Lavalink (Server Side) (Note: DOES NOT RESUME WHEN THE LAVALINK SERVER DIES) |
-sessionId | string | Session ID for lavalink to resume |
 resumeTimeout | number | Timeout before resuming a connection **in seconds** |
 resumeByLibrary | boolean | Whether to resume the players by doing it in the library side (Client Side) (Note: TRIES TO RESUME REGARDLESS OF WHAT HAPPENED ON A LAVALINK SERVER) |
 reconnectTries | number | Number of times to try and reconnect to Lavalink before giving up |

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -25,16 +25,14 @@ export enum OPCodes {
 }
 
 export enum Versions {
-    REST_VERSION = 3,
-    WEBSOCKET_VERSION = 3
+    REST_VERSION = 4,
+    WEBSOCKET_VERSION = 4
 }
 
 export const ShoukakuDefaults: ShoukakuOptions = {
     resume: false,
-    resumeKey: `Shoukaku@${Info.version}(${Info.repository.url})`,
     resumeTimeout: 30,
     resumeByLibrary: false,
-    alwaysSendResumeKey: false,
     reconnectTries: 3,
     reconnectInterval: 5,
     restTimeout: 60,

--- a/src/Shoukaku.ts
+++ b/src/Shoukaku.ts
@@ -47,10 +47,6 @@ export interface ShoukakuOptions {
      */
     resume?: boolean;
     /**
-     * Session ID for lavalink to resume
-     */
-    sessionId?: string;
-    /**
      * Time to wait before lavalink starts to destroy the players of the disconnected client
      */
     resumeTimeout?: number;
@@ -99,7 +95,6 @@ export interface VoiceChannelOptions {
 
 export interface MergedShoukakuOptions {
     resume: boolean;
-    sessionId: string;
     resumeTimeout: number;
     resumeByLibrary: boolean;
     reconnectTries: number;
@@ -192,7 +187,6 @@ export class Shoukaku extends EventEmitter {
      * @param nodes An array that conforms to the NodeOption type that specifies nodes to connect to
      * @param options Options to pass to create this Shoukaku instance
      * @param options.resume Whether to resume a connection on disconnect to Lavalink (Server Side) (Note: DOES NOT RESUME WHEN THE LAVALINK SERVER DIES)
-     * @param options.sessionId Session ID for lavalink to resume
      * @param options.resumeTimeout Time to wait before lavalink starts to destroy the players of the disconnected client
      * @param options.resumeByLibrary Whether to resume the players by doing it in the library side (Client Side) (Note: TRIES TO RESUME REGARDLESS OF WHAT HAPPENED ON A LAVALINK SERVER)
      * @param options.reconnectTries Number of times to try and reconnect to Lavalink before giving up

--- a/src/Shoukaku.ts
+++ b/src/Shoukaku.ts
@@ -59,10 +59,6 @@ export interface ShoukakuOptions {
      */
     resumeByLibrary?: boolean;
     /**
-     * Disables the first time initialization tracking of nodes, and just sends the session id always (Note: Useful for people who save their players to redis and wants to resume sessions even at first boot)
-     */
-    alwaysSendSessionId?: boolean;
-    /**
      * Number of times to try and reconnect to Lavalink before giving up
      */
     reconnectTries?: number;
@@ -106,7 +102,6 @@ export interface MergedShoukakuOptions {
     sessionId: string;
     resumeTimeout: number;
     resumeByLibrary: boolean;
-    alwaysSendSessionId: boolean;
     reconnectTries: number;
     reconnectInterval: number;
     restTimeout: number;
@@ -200,7 +195,6 @@ export class Shoukaku extends EventEmitter {
      * @param options.sessionId Session ID for lavalink to resume
      * @param options.resumeTimeout Time to wait before lavalink starts to destroy the players of the disconnected client
      * @param options.resumeByLibrary Whether to resume the players by doing it in the library side (Client Side) (Note: TRIES TO RESUME REGARDLESS OF WHAT HAPPENED ON A LAVALINK SERVER)
-     * @param options.alwaysSendSessionId Disables the first time initialization tracking of nodes, and just sends the session id always (Note: Useful for people who save their players to redis and wants to resume sessions even at first boot)
      * @param options.reconnectTries Number of times to try and reconnect to Lavalink before giving up
      * @param options.reconnectInterval Timeout before trying to reconnect
      * @param options.restTimeout Time to wait for a response from the Lavalink REST API before giving up

--- a/src/Shoukaku.ts
+++ b/src/Shoukaku.ts
@@ -47,9 +47,9 @@ export interface ShoukakuOptions {
      */
     resume?: boolean;
     /**
-     * Resume key for Lavalink
+     * Session ID for lavalink to resume
      */
-    resumeKey?: string;
+    sessionId?: string;
     /**
      * Time to wait before lavalink starts to destroy the players of the disconnected client
      */
@@ -59,9 +59,9 @@ export interface ShoukakuOptions {
      */
     resumeByLibrary?: boolean;
     /**
-     * Disables the first time initialization tracking of nodes, and just sends the resume key always (Note: Useful for people who save their players to redis and wants to resume sessions even at first boot)
+     * Disables the first time initialization tracking of nodes, and just sends the session id always (Note: Useful for people who save their players to redis and wants to resume sessions even at first boot)
      */
-    alwaysSendResumeKey?: boolean;
+    alwaysSendSessionId?: boolean;
     /**
      * Number of times to try and reconnect to Lavalink before giving up
      */
@@ -103,10 +103,10 @@ export interface VoiceChannelOptions {
 
 export interface MergedShoukakuOptions {
     resume: boolean;
-    resumeKey: string;
+    sessionId: string;
     resumeTimeout: number;
     resumeByLibrary: boolean;
-    alwaysSendResumeKey: boolean;
+    alwaysSendSessionId: boolean;
     reconnectTries: number;
     reconnectInterval: number;
     restTimeout: number;
@@ -197,10 +197,10 @@ export class Shoukaku extends EventEmitter {
      * @param nodes An array that conforms to the NodeOption type that specifies nodes to connect to
      * @param options Options to pass to create this Shoukaku instance
      * @param options.resume Whether to resume a connection on disconnect to Lavalink (Server Side) (Note: DOES NOT RESUME WHEN THE LAVALINK SERVER DIES)
-     * @param options.resumeKey Resume key for Lavalink
+     * @param options.sessionId Session ID for lavalink to resume
      * @param options.resumeTimeout Time to wait before lavalink starts to destroy the players of the disconnected client
      * @param options.resumeByLibrary Whether to resume the players by doing it in the library side (Client Side) (Note: TRIES TO RESUME REGARDLESS OF WHAT HAPPENED ON A LAVALINK SERVER)
-     * @param options.alwaysSendResumeKey Disables the first time initialization tracking of nodes, and just sends the resume key always (Note: Useful for people who save their players to redis and wants to resume sessions even at first boot)
+     * @param options.alwaysSendSessionId Disables the first time initialization tracking of nodes, and just sends the session id always (Note: Useful for people who save their players to redis and wants to resume sessions even at first boot)
      * @param options.reconnectTries Number of times to try and reconnect to Lavalink before giving up
      * @param options.reconnectInterval Timeout before trying to reconnect
      * @param options.restTimeout Time to wait for a response from the Lavalink REST API before giving up

--- a/src/node/Node.ts
+++ b/src/node/Node.ts
@@ -181,7 +181,7 @@ export class Node extends EventEmitter {
                 'User-Agent': this.manager.options.userAgent,
                 'Authorization': this.auth,
                 'User-Id': this.manager.id,
-                'Session-Id': this.sessionId!
+                'Session-Id': this.sessionId
             };
         } else {
             headers = {

--- a/src/node/Node.ts
+++ b/src/node/Node.ts
@@ -183,7 +183,7 @@ export class Node extends EventEmitter {
                 'User-Agent': this.manager.options.userAgent,
                 'Authorization': this.auth,
                 'User-Id': this.manager.id,
-                'Session-Id': this.manager.options.sessionId
+                'Session-Id': this.sessionId!
             };
         } else {
             headers = {

--- a/src/node/Node.ts
+++ b/src/node/Node.ts
@@ -103,7 +103,7 @@ export class Node extends EventEmitter {
      */
     public sessionId: string|null;
     /**
-     * Boolean that represents if the node has initialized once (will always be true when alwaysSendResumeKey is true)
+     * Boolean that represents if the node has initialized once
      */
     protected initialized: boolean;
     /**
@@ -134,7 +134,7 @@ export class Node extends EventEmitter {
         this.stats = null;
         this.ws = null;
         this.sessionId = null;
-        this.initialized = this.manager.options.alwaysSendSessionId ?? false;
+        this.initialized = false;
         this.destroyed = false;
     }
 

--- a/src/node/Node.ts
+++ b/src/node/Node.ts
@@ -173,11 +173,9 @@ export class Node extends EventEmitter {
         if (!this.manager.id) throw new Error('Don\'t connect a node when the library is not yet ready');
         if (this.destroyed) throw new Error('You can\'t re-use the same instance of a node once disconnected, please re-add the node again');
 
-        const resume = this.initialized && (this.manager.options.resume && this.manager.options.sessionId);
-        this.state = State.CONNECTING;
         let headers: ResumableHeaders|NonResumableHeaders;
 
-        if (resume) {
+        if (this.sessionId) {
             headers = {
                 'Client-Name': this.manager.options.userAgent,
                 'User-Agent': this.manager.options.userAgent,
@@ -194,7 +192,7 @@ export class Node extends EventEmitter {
             };
         }
 
-        this.emit('debug', `[Socket] -> [${this.name}] : Connecting ${this.url}, Version: ${this.version}, Trying to resume? ${resume}`);
+        this.emit('debug', `[Socket] -> [${this.name}] : Connecting ${this.url}, Version: ${this.version}, Trying to resume? ${this.sessionId ? 'yes' : 'no'}`);
 
         if (!this.initialized) this.initialized = true;
 
@@ -267,7 +265,7 @@ export class Node extends EventEmitter {
                 this.emit('debug', `[Socket] -> [${this.name}] : Lavalink is ready! | Lavalink resume: ${json.resumed} | Lib resume: ${!!resumeByLibrary}`);
                 this.emit('ready', json.resumed || resumeByLibrary);
 
-                if (this.manager.options.resume && this.manager.options.sessionId) {
+                if (this.manager.options.resume) {
                     await this.rest.updateSession(this.manager.options.resume, this.manager.options.resumeTimeout);
                     this.emit('debug', `[Socket] -> [${this.name}] : Resuming configured!`);
                 }

--- a/src/node/Node.ts
+++ b/src/node/Node.ts
@@ -35,7 +35,7 @@ export interface ResumableHeaders {
     'User-Agent': string;
     'Authorization': string;
     'User-Id': string;
-    'Resume-Key': string;
+    'Session-Id': string;
 }
 
 export interface NonResumableHeaders {

--- a/src/node/Node.ts
+++ b/src/node/Node.ts
@@ -134,7 +134,7 @@ export class Node extends EventEmitter {
         this.stats = null;
         this.ws = null;
         this.sessionId = null;
-        this.initialized = this.manager.options.alwaysSendResumeKey ?? false;
+        this.initialized = this.manager.options.alwaysSendSessionId ?? false;
         this.destroyed = false;
     }
 
@@ -173,7 +173,7 @@ export class Node extends EventEmitter {
         if (!this.manager.id) throw new Error('Don\'t connect a node when the library is not yet ready');
         if (this.destroyed) throw new Error('You can\'t re-use the same instance of a node once disconnected, please re-add the node again');
 
-        const resume = this.initialized && (this.manager.options.resume && this.manager.options.resumeKey);
+        const resume = this.initialized && (this.manager.options.resume && this.manager.options.sessionId);
         this.state = State.CONNECTING;
         let headers: ResumableHeaders|NonResumableHeaders;
 
@@ -183,7 +183,7 @@ export class Node extends EventEmitter {
                 'User-Agent': this.manager.options.userAgent,
                 'Authorization': this.auth,
                 'User-Id': this.manager.id,
-                'Resume-Key': this.manager.options.resumeKey
+                'Session-Id': this.manager.options.sessionId
             };
         } else {
             headers = {
@@ -267,8 +267,8 @@ export class Node extends EventEmitter {
                 this.emit('debug', `[Socket] -> [${this.name}] : Lavalink is ready! | Lavalink resume: ${json.resumed} | Lib resume: ${!!resumeByLibrary}`);
                 this.emit('ready', json.resumed || resumeByLibrary);
 
-                if (this.manager.options.resume && this.manager.options.resumeKey) {
-                    await this.rest.updateSession(this.manager.options.resumeKey, this.manager.options.resumeTimeout);
+                if (this.manager.options.resume && this.manager.options.sessionId) {
+                    await this.rest.updateSession(this.manager.options.resume, this.manager.options.resumeTimeout);
                     this.emit('debug', `[Socket] -> [${this.name}] : Resuming configured!`);
                 }
                 break;

--- a/src/node/Rest.ts
+++ b/src/node/Rest.ts
@@ -1,7 +1,7 @@
 import { Node, NodeStats } from './Node';
 import { NodeOption } from '../Shoukaku';
 import { Versions } from '../Constants';
-import { FilterOptions } from '../guild/Player';
+import { Exception, FilterOptions } from '../guild/Player';
 
 export type LoadType = 'TRACK_LOADED' | 'PLAYLIST_LOADED' | 'SEARCH_RESULT' | 'NO_MATCHES' | 'LOAD_FAILED';
 
@@ -17,8 +17,6 @@ interface FetchOptions {
 }
 
 export interface Track {
-    /** @deprecated */
-    track: string;
     encoded: string;
     info: {
         identifier: string;
@@ -29,18 +27,46 @@ export interface Track {
         position: number;
         title: string;
         uri?: string;
+        artworkUrl?: string;
+        isrc?: string;
         sourceName: string;
+    }
+    pluginInfo: object;
+}
+
+export interface TrackLoadResult {
+    loadType: 'track';
+    data: Track;
+}
+
+export interface PlaylistLoadResult {
+    loadType: 'playlist';
+    data: {
+        info: {
+            name: string;
+            selectedTrack: number;
+        }
+        pluginInfo: object;
+        tracks: Track[];
     }
 }
 
-export interface LavalinkResponse {
-    loadType: LoadType;
-    playlistInfo: {
-        name?: string;
-        selectedTrack?: number;
-    }
-    tracks: Track[]
+export interface SearchLoadResult {
+    loadType: 'search';
+    data: Track[];
 }
+
+export interface EmptyLoadResult {
+    loadType: 'empty';
+    data: {};
+}
+
+export interface ErrorLoadResult {
+    loadType: 'error';
+    data: Exception;
+}
+
+export type LavalinkResponse = TrackLoadResult | PlaylistLoadResult | SearchLoadResult | EmptyLoadResult | ErrorLoadResult;
 
 export interface Address {
     address: string;
@@ -233,18 +259,18 @@ export class Rest {
     }
 
     /**
-     * Updates the session with a resuming key and timeout
-     * @param resumingKey Resuming key to set
+     * Updates the session with a resume boolean and timeout
+     * @param resuming Whether resuming is enabled for this session or not
      * @param timeout Timeout to wait for resuming
      * @returns Promise that resolves to a Lavalink player
      */
-    public updateSession(resumingKey?: string, timeout?: number): Promise<SessionInfo | undefined> {
+    public updateSession(resuming?: boolean, timeout?: number): Promise<SessionInfo | undefined> {
         const options = {
             endpoint: `/sessions/${this.sessionId}`,
             options: {
                 method: 'PATCH',
                 headers: { 'Content-Type': 'application/json' },
-                body: { resumingKey, timeout }
+                body: { resuming, timeout }
             }
         };
         return this.fetch(options);

--- a/src/node/Rest.ts
+++ b/src/node/Rest.ts
@@ -3,7 +3,7 @@ import { NodeOption } from '../Shoukaku';
 import { Versions } from '../Constants';
 import { Exception, FilterOptions } from '../guild/Player';
 
-export type LoadType = 'TRACK_LOADED' | 'PLAYLIST_LOADED' | 'SEARCH_RESULT' | 'NO_MATCHES' | 'LOAD_FAILED';
+export type LoadType = 'track' | 'playlist' | 'search' | 'empty' | 'error';
 
 interface FetchOptions {
     endpoint: string;

--- a/src/node/Rest.ts
+++ b/src/node/Rest.ts
@@ -3,7 +3,13 @@ import { NodeOption } from '../Shoukaku';
 import { Versions } from '../Constants';
 import { Exception, FilterOptions } from '../guild/Player';
 
-export type LoadType = 'track' | 'playlist' | 'search' | 'empty' | 'error';
+export enum LoadType {
+    TRACK = 'track',
+    PLAYLIST = 'playlist',
+    SEARCH = 'search',
+    EMPTY = 'empty',
+    ERROR = 'error'
+}
 
 interface FetchOptions {
     endpoint: string;
@@ -35,12 +41,12 @@ export interface Track {
 }
 
 export interface TrackLoadResult {
-    loadType: 'track';
+    loadType: LoadType.TRACK;
     data: Track;
 }
 
 export interface PlaylistLoadResult {
-    loadType: 'playlist';
+    loadType: LoadType.PLAYLIST;
     data: {
         info: {
             name: string;
@@ -52,17 +58,17 @@ export interface PlaylistLoadResult {
 }
 
 export interface SearchLoadResult {
-    loadType: 'search';
+    loadType: LoadType.SEARCH;
     data: Track[];
 }
 
 export interface EmptyLoadResult {
-    loadType: 'empty';
+    loadType: LoadType.EMPTY;
     data: {};
 }
 
 export interface ErrorLoadResult {
-    loadType: 'error';
+    loadType: LoadType.ERROR;
     data: Exception;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "node16",
+    "module": "es2020",
     "moduleResolution": "node16",
     "outDir": "dist",
     "target": "es2020",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "es2020",
+    "module": "node16",
     "moduleResolution": "node16",
     "outDir": "dist",
     "target": "es2020",


### PR DESCRIPTION
Here's my attempt at implementing Lavalink v4. I followed the implementation documentation, but I can't test these changes.
There are probably issues with this PR, but it should mostly work. I think. The resuming via session ID kinda confuses me too.
Not too experienced with TS, merge / change / close this if y'all wish!

Quoted from Lavalink `IMPLEMENTATION.md`:
## Significant changes v3.7.0 -> v4.0.0

* removed all non version `/v3` or `/v4` endpoints (except `/version`).
* `/v4/websocket` does not accept any messages anymore.
* `v4` uses the `sessionId` instead of the `resumeKey` for resuming.
* `v4` now returns the tracks `artworkUrl` and `isrc` if the source supports it.
* removal of deprecated json fields like `track`.
* addition of `artworkUrl` and `isrc` fields to the [Track Info](#track-info) object.
* addition of the full [Track](#track) object in [TrackStartEvent](#trackstartevent), [TrackEndEvent](#trackendevent), [TrackExceptionEvent](#trackexceptionevent) and [TrackStuckEvent](#trackstuckevent).
* updated capitalization of [Track End Reason](#track-end-reason) and [Severity](#severity)
* reworked [Load Result](#track-loading-result) object

<details>
<summary>v4.0.0 Migration Guide</summary>

All websocket ops are removed as of `v4.0.0` and replaced with the following endpoints and json fields:
* `play` -> [Update Player Endpoint](#update-player) `encodedTrack` or `identifier` field
* `stop` -> [Update Player Endpoint](#update-player) `encodedTrack` field with `null`
* `pause` -> [Update Player Endpoint](#update-player) `pause` field
* `seek` -> [Update Player Endpoint](#update-player) `position` field
* `volume` -> [Update Player Endpoint](#update-player) `volume` field
* `filters` -> [Update Player Endpoint](#update-player) `filters` field
* `destroy` -> [Destroy Player Endpoint](#destroy-player)
* `voiceUpdate` -> [Update Player Endpoint](#update-player) `voice` field
* `configureResuming` -> [Update Session Endpoint](#update-session)

</details>













